### PR TITLE
fix spelling error in swagger/src/lib.rs

### DIFF
--- a/swagger/src/lib.rs
+++ b/swagger/src/lib.rs
@@ -112,7 +112,7 @@ pub struct Header {
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct Encoding {
     #[serde(rename = "contentType")]
-    pub conent_type: Option<String>,
+    pub content_type: Option<String>,
     pub headers: Option<HeaderMap>,
     pub style: Option<String>,
     pub explode: Option<bool>,


### PR DESCRIPTION
this fixes issue #84 